### PR TITLE
Bug/healthv1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MH Custom Tags (ElvUI Plugin)
 
+## <span style="color:white">[4.0.1] Bug Fix (June 13th, 2025)</span>.
+
+### Bug Fixes
+
+- **FIXED**: `formatHealthPercent` function in core.lua not displaying max HP at full health due to incorrect ElvUI function reference
+- **FIXED**: Health tags using `MHCT.formatHealthPercent` now properly show formatted max HP value when at full health instead of showing nothing
+
 ## <span style="color:cyan">[4.0.0] Major update and refactor (May 17th, 2025)</span>.
 
 ### Performance Optimizations

--- a/ElvUI_mhTags.toc
+++ b/ElvUI_mhTags.toc
@@ -2,7 +2,7 @@
 ## Title: |cff1784d1ElvUI|r |cffccff33MH Tags|r
 ## Notes: Custom tags for use across ElvUI
 ## Author: mhDesigns
-## Version: 4.0.0
+## Version: 4.0.1
 ## RequiredDeps: ElvUI
 ## IconTexture: Interface\Addons\ElvUI_mhTags\icons\addon_icon.png
 

--- a/core.lua
+++ b/core.lua
@@ -434,7 +434,7 @@ MHCT.formatHealthPercent = function(unit, decimalPlaces, showSign)
 	end
 
 	if currentHp == maxHp then
-		return GetFormattedText("CURRENT", currentHp, maxHp, nil, true)
+		return E:GetFormattedText("CURRENT", currentHp, maxHp, nil, true)
 	else
 		local numDecimals = tonumber(decimalPlaces) or MHCT.DEFAULT_DECIMAL_PLACE
 

--- a/tags/healthV1.lua
+++ b/tags/healthV1.lua
@@ -158,11 +158,12 @@ MHCT.registerTag(
 )
 
 -- Simple Percent with status
+-- Simple Percent with status
 MHCT.registerTag(
 	"mh-health:simple:percent",
 	HEALTH_SUBCATEGORY,
 	"Shows max hp at full or percent with dynamic # of decimals (dynamic number within {} of tag) - Example: [mh-health:simple:percent{2}] will show percent to 2 decimal places",
-	"PLAYER_FLAGS_CHANGED UNIT_CONNECTION UNIT_HEALTH",
+	"PLAYER_FLAGS_CHANGED UNIT_CONNECTION UNIT_HEALTH UNIT_MAXHEALTH",
 	function(unit, _, args)
 		local statusFormatted = MHCT.formatWithStatusCheck(unit)
 		if statusFormatted then

--- a/tags/healthV1.lua
+++ b/tags/healthV1.lua
@@ -158,7 +158,6 @@ MHCT.registerTag(
 )
 
 -- Simple Percent with status
--- Simple Percent with status
 MHCT.registerTag(
 	"mh-health:simple:percent",
 	HEALTH_SUBCATEGORY,


### PR DESCRIPTION
This pull request includes updates to the `MH Custom Tags` ElvUI plugin, focusing on bug fixes and version updates. The most important changes address a bug in the `formatHealthPercent` function, ensuring proper display of max HP at full health, and updating relevant metadata files to reflect the new version.

### Bug Fixes:
* [`core.lua`](diffhunk://#diff-9fd312a11a5485b36097d320642df29ae3b3ad1dd1570d77464a01a01782deb1L437-R437): Corrected the `formatHealthPercent` function to use the proper ElvUI reference (`E:GetFormattedText`), fixing the issue where max HP was not displayed at full health.
* [`tags/healthV1.lua`](diffhunk://#diff-34c523c5ee4cb88efe200cea850605cff7303f651c9a93a8e2d887a6bb065cc1R160-R166): Updated the event list for the `mh-health:simple:percent` tag to include `UNIT_MAXHEALTH`, ensuring accurate updates when max health changes.

### Version Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9): Added a new section for version `4.0.1`, detailing the bug fixes introduced in this update.
* [`ElvUI_mhTags.toc`](diffhunk://#diff-2320d73ee63885771719e864ec419fe3edf80e76ff5b1b2b7f9c666b25181ea4L5-R5): Updated the version number from `4.0.0` to `4.0.1` in the metadata file.