### PR TITLE
v11: health gradient, absorb fix, WoW 12.0.5 target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ $RECYCLE.BIN/
 *.old
 *.orig
 
+# Agent / scratch research files (not part of the addon)
+agent-tools/
+
 # Ignore files and folders related to packaged releases (e.g., if using tools like CurseForge)
 release/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ v11 requires WoW 12.0.5 (Midnight) and ElvUI 15.0+. It refactors the codebase ar
 
 ### Fixed
 
-- **Absorb display** — `(0)` no longer shown when absorb is zero or a secret zero; uses `TruncateWhenZero` + `WrapString` for C-side empty detection, then `AbbreviateNumbers` for display (secret values stay abbreviated; never compare secret strings to `""` in Lua)
+- **Absorb display** — `(0)` no longer shown when absorb is zero. Non-secret absorbs use `AbbreviateNumbers` (e.g. `(92.6K)`); secret absorbs use `TruncateWhenZero` + `WrapString` and show the raw integer (e.g. `(92587)`). Blizzard does not currently expose an API to combine abbreviation with hide-when-zero on secret values — confirmed by oUF maintainer and Blizzard forum (Feb 2026).
 - **Status/classification colors** — shared via `MHCT.COLORS` so tags stay in sync
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ v11 requires WoW 12.0.7 (Midnight) and ElvUI 15.0+. It refactors the codebase ar
 
 ### Fixed
 
-- **Absorb display** — `(0)` no longer shown when absorb is a secret zero (`C_StringUtil.TruncateWhenZero`)
+- **Absorb display** — `(0)` no longer shown when absorb is zero or a secret zero; fix checks `C_StringUtil.TruncateWhenZero` for `""` (empty string is truthy in Lua, so `not TruncateWhenZero(...)` never suppressed output)
 - **Status/classification colors** — shared via `MHCT.COLORS` so tags stay in sync
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses simple integer versions: 1, 2, 3, and so on.
 
 ## [11] - May 20, 2026
 
-v11 requires WoW 12.0.7 (Midnight) and ElvUI 15.0+. It refactors the codebase around shared core helpers and restores health-percent text coloring using Blizzard's ColorCurve API.
+v11 requires WoW 12.0.5 (Midnight) and ElvUI 15.0+. It refactors the codebase around shared core helpers and restores health-percent text coloring using Blizzard's ColorCurve API.
 
 ### Added
 
@@ -21,11 +21,11 @@ v11 requires WoW 12.0.7 (Midnight) and ElvUI 15.0+. It refactors the codebase ar
 - **Centralized tag logic** — absorb, percent formatting, name handling, and max-level comparisons moved into `core.lua`; tag files delegate instead of duplicating
 - **Health deficit tags** — use `MHCT.FormatLargeNumber` (`AbbreviateNumbers`) for consistent abbreviation with other health tags
 - **12.0+ API cleanup** — `AbbreviateNumbers` and `C_StringUtil.TruncateWhenZero` for number/absorb formatting; load-time `CurveConstants.ScaleTo100` path for percent helpers; removed unnecessary `pcall` wrappers on boolean APIs
-- **Documentation** — README and TOC updated for v11 and WoW 12.0.7 (`Interface: 120007`)
+- **Documentation** — README and TOC updated for v11 and WoW 12.0.5 (`Interface: 120005`)
 
 ### Fixed
 
-- **Absorb display** — `(0)` no longer shown when absorb is zero or a secret zero; fix checks `C_StringUtil.TruncateWhenZero` for `""` (empty string is truthy in Lua, so `not TruncateWhenZero(...)` never suppressed output)
+- **Absorb display** — `(0)` no longer shown when absorb is zero or a secret zero; uses `TruncateWhenZero` + `WrapString` for C-side empty detection, then `AbbreviateNumbers` for display (secret values stay abbreviated; never compare secret strings to `""` in Lua)
 - **Status/classification colors** — shared via `MHCT.COLORS` so tags stay in sync
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This project uses simple integer versions: 1, 2, 3, and so on.
 
 ---
 
+## [11] - May 20, 2026
+
+v11 requires WoW 12.0.5+ (Midnight) and ElvUI 15.0+. It refactors the codebase around shared core helpers and restores health-percent text coloring using Blizzard's ColorCurve API.
+
+### Added
+
+- **`[mh-color-health-gradient]`** — health-percent text gradient prefix (emerald-red → emerald-yellow → emerald-green). Composes with any health tag. Uses `UnitHealthPercent` + `ColorCurveObject` so it works with Midnight secret values (Lua table lookup cannot).
+- **Shared core helpers** — `MHCT.getAbsorbText`, `MHCT.getUnitNameSafe`, `MHCT.getFormattedUnitName`, `MHCT.isAtMaxLevelTogether`, `MHCT.COLORS`, `MHCT.EMERALD_HEX`
+
+### Changed
+
+- **Centralized tag logic** — absorb, percent formatting, name handling, and max-level comparisons moved into `core.lua`; tag files delegate instead of duplicating
+- **Health deficit tags** — use `MHCT.FormatLargeNumber` (`AbbreviateNumbers`) for consistent abbreviation with other health tags
+- **12.0+ API cleanup** — `AbbreviateNumbers` and `C_StringUtil.TruncateWhenZero` for number/absorb formatting; load-time `CurveConstants.ScaleTo100` path for percent helpers; removed unnecessary `pcall` wrappers on boolean APIs
+- **Documentation** — README and TOC updated for v11; midnight notes reflect ColorCurve gradient support
+
+### Fixed
+
+- **Absorb display** — `(0)` no longer shown when absorb is a secret zero (`C_StringUtil.TruncateWhenZero`)
+- **Status/classification colors** — shared via `MHCT.COLORS` so tags stay in sync
+
+---
+
 ## [10] - April 25, 2026
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses simple integer versions: 1, 2, 3, and so on.
 
 ## [11] - May 20, 2026
 
-v11 requires WoW 12.0.5+ (Midnight) and ElvUI 15.0+. It refactors the codebase around shared core helpers and restores health-percent text coloring using Blizzard's ColorCurve API.
+v11 requires WoW 12.0.7 (Midnight) and ElvUI 15.0+. It refactors the codebase around shared core helpers and restores health-percent text coloring using Blizzard's ColorCurve API.
 
 ### Added
 
@@ -21,7 +21,7 @@ v11 requires WoW 12.0.5+ (Midnight) and ElvUI 15.0+. It refactors the codebase a
 - **Centralized tag logic** — absorb, percent formatting, name handling, and max-level comparisons moved into `core.lua`; tag files delegate instead of duplicating
 - **Health deficit tags** — use `MHCT.FormatLargeNumber` (`AbbreviateNumbers`) for consistent abbreviation with other health tags
 - **12.0+ API cleanup** — `AbbreviateNumbers` and `C_StringUtil.TruncateWhenZero` for number/absorb formatting; load-time `CurveConstants.ScaleTo100` path for percent helpers; removed unnecessary `pcall` wrappers on boolean APIs
-- **Documentation** — README and TOC updated for v11; midnight notes reflect ColorCurve gradient support
+- **Documentation** — README and TOC updated for v11 and WoW 12.0.7 (`Interface: 120007`)
 
 ### Fixed
 

--- a/ElvUI_mhTags.toc
+++ b/ElvUI_mhTags.toc
@@ -1,6 +1,6 @@
-## Interface: 120005
+## Interface: 120007
 ## Title: |cff1784d1ElvUI|r |cffccff33MH Tags|r
-## Notes: Custom tags for ElvUI unit frames. WoW 12.0.5+ (Midnight) only. Includes secret-safe health gradient coloring via ColorCurve.
+## Notes: Custom tags for ElvUI unit frames. WoW 12.0.7 (Midnight) Retail. Includes secret-safe health gradient coloring via ColorCurve.
 ## Author: mhDesigns
 ## Version: 11
 ## X-Category: Unit Frames
@@ -13,7 +13,7 @@
 ## X-License: GPL-3.0
 ## X-Localizations: enUS
 ## X-Min-ElvUI: 15.0
-## X-WoW-Version: 12.0.5
+## X-WoW-Version: 12.0.7
 ## X-Flavor: Retail
 
 core.lua

--- a/ElvUI_mhTags.toc
+++ b/ElvUI_mhTags.toc
@@ -1,8 +1,8 @@
 ## Interface: 120005
 ## Title: |cff1784d1ElvUI|r |cffccff33MH Tags|r
-## Notes: Custom tags for ElvUI unit frames. WoW 12.0.5+ (Midnight) only. Health gradient colors removed due to Blizzard secret value restrictions.
+## Notes: Custom tags for ElvUI unit frames. WoW 12.0.5+ (Midnight) only. Includes secret-safe health gradient coloring via ColorCurve.
 ## Author: mhDesigns
-## Version: 10
+## Version: 11
 ## X-Category: Unit Frames
 ## Category: Unit Frames
 ## Group: ElvUI

--- a/ElvUI_mhTags.toc
+++ b/ElvUI_mhTags.toc
@@ -1,6 +1,6 @@
-## Interface: 120007
+## Interface: 120005
 ## Title: |cff1784d1ElvUI|r |cffccff33MH Tags|r
-## Notes: Custom tags for ElvUI unit frames. WoW 12.0.7 (Midnight) Retail. Includes secret-safe health gradient coloring via ColorCurve.
+## Notes: Custom tags for ElvUI unit frames. WoW 12.0.5 (Midnight) Retail. Includes secret-safe health gradient coloring via ColorCurve.
 ## Author: mhDesigns
 ## Version: 11
 ## X-Category: Unit Frames
@@ -13,7 +13,7 @@
 ## X-License: GPL-3.0
 ## X-Localizations: enUS
 ## X-Min-ElvUI: 15.0
-## X-WoW-Version: 12.0.7
+## X-WoW-Version: 12.0.5
 ## X-Flavor: Retail
 
 core.lua

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Color tags return an opening color code. Use them before another tag and close w
 ```text
 [mh-color-pastel-green][mh-health-current-percent]|r
 [mh-color-custom{FF5733}][mh-name-caps{20}]|r
+[mh-color-health-gradient][mh-health-current-percent]|r
 ```
+
+- `[mh-color-health-gradient]`: health-percent gradient prefix using the emerald palette (emerald-red at low, emerald-yellow at mid, emerald-green at full). Uses Blizzard's ColorCurve API for Midnight secret-value compatibility. Example: `[mh-color-health-gradient][mh-health-current-percent]|r`
 
 Available color groups:
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Version](https://img.shields.io/badge/Version-11-brightgreen)](https://github.com/masomh-personal/ElvUI_mhTags)
 [![ElvUI](https://img.shields.io/badge/Requires-ElvUI%2015.0+-blue)](https://www.tukui.org/download.php?ui=elvui)
-[![WoW](https://img.shields.io/badge/WoW-12.0.5%20Midnight+-orange)](https://worldofwarcraft.com)
+[![WoW](https://img.shields.io/badge/WoW-12.0.7%20Midnight-orange)](https://worldofwarcraft.com)
 [![License](https://img.shields.io/badge/License-GPL--3.0-yellow)](LICENSE)
 
-Custom tags for ElvUI unit frames on WoW Retail 12.0.5+ (Midnight).
+Custom tags for ElvUI unit frames on WoW Retail 12.0.7 (Midnight).
 
 ElvUI_mhTags adds health, power, name, classification, level, status, combined, and color-prefix tags for ElvUI Custom Texts. It is lightweight, Retail-only, and updated for Midnight's secret-value restrictions.
 
@@ -21,7 +21,7 @@ Known behavior:
 
 ## Requirements
 
-- World of Warcraft Retail 12.0.5+ (Midnight)
+- World of Warcraft Retail 12.0.7 (Midnight)
 - ElvUI 15.0+
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Because secret values cannot be compared, used for arithmetic, or used as table 
 
 Known behavior:
 
-- Absorb tags may show `(0)` when a zero absorb value is secret.
 - Deficit percent is hidden when WoW blocks the arithmetic needed to calculate it.
 - Secret names display as-is and are not uppercased, shortened, or abbreviated.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ElvUI_mhTags
 
-[![Version](https://img.shields.io/badge/Version-10-brightgreen)](https://github.com/masomh-personal/ElvUI_mhTags)
+[![Version](https://img.shields.io/badge/Version-11-brightgreen)](https://github.com/masomh-personal/ElvUI_mhTags)
 [![ElvUI](https://img.shields.io/badge/Requires-ElvUI%2015.0+-blue)](https://www.tukui.org/download.php?ui=elvui)
 [![WoW](https://img.shields.io/badge/WoW-12.0.5%20Midnight+-orange)](https://worldofwarcraft.com)
 [![License](https://img.shields.io/badge/License-GPL--3.0-yellow)](LICENSE)
@@ -11,12 +11,11 @@ ElvUI_mhTags adds health, power, name, classification, level, status, combined, 
 
 ## Midnight Notes
 
-WoW 12 introduced secret values for some combat-sensitive data. This can affect health, power, absorb, and nameplate-related information in protected content.
-
-Because secret values cannot be compared, used for arithmetic, or used as table keys, this addon does not include health-gradient or hide-at-full health tags.
+WoW 12 introduced secret values for some combat-sensitive data. This addon uses Blizzard's 12.0 APIs (`AbbreviateNumbers`, `C_StringUtil.TruncateWhenZero`, `ColorCurveObject`, and related helpers) to stay compatible.
 
 Known behavior:
 
+- Health text gradient uses `[mh-color-health-gradient]` with Blizzard's ColorCurve API (not Lua percent math).
 - Deficit percent is hidden when WoW blocks the arithmetic needed to calculate it.
 - Secret names display as-is and are not uppercased, shortened, or abbreviated.
 
@@ -38,6 +37,7 @@ Open ElvUI with `/ec`, choose a unit frame, open Custom Texts, and browse the `m
 Popular examples:
 
 - `[mh-health-current-percent]`: `100k | 85%`
+- `[mh-color-health-gradient][mh-health-current-percent]|r`: health text with emerald gradient by percent
 - `[mh-health-percent{0}]`: `85%`
 - `[mh-health-deficit]`: `-15k`, or a status such as `DEAD`
 - `[mh-name-caps{20}]`: uppercase name capped to 20 characters

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Version](https://img.shields.io/badge/Version-11-brightgreen)](https://github.com/masomh-personal/ElvUI_mhTags)
 [![ElvUI](https://img.shields.io/badge/Requires-ElvUI%2015.0+-blue)](https://www.tukui.org/download.php?ui=elvui)
-[![WoW](https://img.shields.io/badge/WoW-12.0.7%20Midnight-orange)](https://worldofwarcraft.com)
+[![WoW](https://img.shields.io/badge/WoW-12.0.5%20Midnight-orange)](https://worldofwarcraft.com)
 [![License](https://img.shields.io/badge/License-GPL--3.0-yellow)](LICENSE)
 
-Custom tags for ElvUI unit frames on WoW Retail 12.0.7 (Midnight).
+Custom tags for ElvUI unit frames on WoW Retail 12.0.5 (Midnight).
 
 ElvUI_mhTags adds health, power, name, classification, level, status, combined, and color-prefix tags for ElvUI Custom Texts. It is lightweight, Retail-only, and updated for Midnight's secret-value restrictions.
 
@@ -21,7 +21,7 @@ Known behavior:
 
 ## Requirements
 
-- World of Warcraft Retail 12.0.7 (Midnight)
+- World of Warcraft Retail 12.0.5 (Midnight)
 - ElvUI 15.0+
 
 ## Installation

--- a/core.lua
+++ b/core.lua
@@ -378,23 +378,27 @@ end
 -- withTrailingSpace: true for inline use before a health value (e.g. "(25k) 100k").
 --
 -- Zero-detection strategy:
---   Non-secret: direct comparison (absorbAmount <= 0), then AbbreviateNumbers
---   Secret:     TruncateWhenZero + WrapString gate (C-side empty check); display via
---               AbbreviateNumbers (secret-safe). Never compare TruncateWhenZero output to "" in Lua.
+--   Non-secret: absorbAmount <= 0, then AbbreviateNumbers in parens (e.g. "(92.6K)")
+--   Secret:     TruncateWhenZero + WrapString only. Blizzard's APIs do not currently support
+--               combining AbbreviateNumbers with hide-when-zero on secret values
+--               (TruncateWhenZero only accepts numbers, AbbreviateNumbers always emits "0").
+--               Shows raw integer in parens when present. Confirmed by oUF maintainer p3lim
+--               and on the Blizzard forums; cannot be worked around in addon code.
 MHCT.getAbsorbText = function(unit, withTrailingSpace)
 	if not unit then return "" end
 
 	local absorbAmount = UnitGetTotalAbsorbs(unit)
+	if absorbAmount == nil then return "" end
 
 	if not issecretvalue(absorbAmount) then
-		if absorbAmount == nil or absorbAmount <= 0 then return "" end
+		if absorbAmount <= 0 then return "" end
 		local result = AbbreviateNumbers(absorbAmount)
 		if result == nil or result == "" or result == "0" then return "" end
 		local text = strconcat("(", result, ")")
 		return withTrailingSpace and strconcat(text, " ") or text
 	end
 
-	-- Secret absorb: TruncateWhenZero only accepts numbers (not abbreviated strings).
+	-- Secret path: never call AbbreviateNumbers — it always formats zero as "0".
 	if type(absorbAmount) ~= "number" or not TruncateWhenZero or not WrapString then
 		return ""
 	end
@@ -402,15 +406,8 @@ MHCT.getAbsorbText = function(unit, withTrailingSpace)
 	local infix = TruncateWhenZero(absorbAmount)
 	if infix == nil then return "" end
 
-	-- WrapString returns normal "" when infix is empty (zero absorb); only compare when not secret.
-	local gate = WrapString(infix)
-	if not issecretvalue(gate) and gate == "" then return "" end
-
-	local result = AbbreviateNumbers(absorbAmount)
-	if not issecretvalue(result) and (result == nil or result == "" or result == "0") then return "" end
-
-	local text = strconcat("(", result, ")")
-	return withTrailingSpace and strconcat(text, " ") or text
+	local suffix = withTrailingSpace and ") " or ")"
+	return WrapString(infix, "(", suffix)
 end
 
 -- Build a ColorCurveObject from HEALTH_GRADIENT_STOPS (0%, 50%, 100%).

--- a/core.lua
+++ b/core.lua
@@ -28,6 +28,7 @@ local gmatch = string.gmatch
 local sub = string.sub
 local tinsert = table.insert
 local concat = table.concat
+local unpack = unpack
 local strupper = strupper
 local strtrim = strtrim
 
@@ -57,6 +58,9 @@ local GetRaidRosterInfo = GetRaidRosterInfo
 local UnitHealthPercent = UnitHealthPercent
 local UnitPowerPercent = UnitPowerPercent
 local UnitGetTotalAbsorbs = UnitGetTotalAbsorbs
+local CreateColor = CreateColor
+local CreateColorCurve = C_CurveUtil and C_CurveUtil.CreateColorCurve
+local LuaCurveTypeLinear = Enum.LuaCurveType and Enum.LuaCurveType.Linear
 -- AbbreviateNumbers is AllowedWhenTainted in 12.0+ and accepts secret values natively.
 -- Guaranteed to exist since TOC floor is 120005.
 local AbbreviateNumbers = AbbreviateNumbers
@@ -159,6 +163,32 @@ MHCT.COLORS = {
 	RARE   = "fc49f3", -- light magenta
 	ELITE  = "ffcc00", -- gold
 }
+
+-- Emerald palette (hex values match mh-color-emerald-* in tags/color.lua)
+MHCT.EMERALD_HEX = {
+	RED    = "C85050",
+	YELLOW = "C8C850",
+	GREEN  = "50C878",
+}
+
+-- Convert 6-char hex ("RRGGBB") to normalized RGB (0-1) for ColorCurve stop definitions.
+local function gradientStopFromHex(hex)
+	return tonumber(sub(hex, 1, 2), 16) / 255,
+		tonumber(sub(hex, 3, 4), 16) / 255,
+		tonumber(sub(hex, 5, 6), 16) / 255
+end
+
+-- Health gradient: emerald-red (0%) -> emerald-yellow (50%) -> emerald-green (100%)
+do
+	local lr, lg, lb = gradientStopFromHex(MHCT.EMERALD_HEX.RED)
+	local mr, mg, mb = gradientStopFromHex(MHCT.EMERALD_HEX.YELLOW)
+	local hr, hg, hb = gradientStopFromHex(MHCT.EMERALD_HEX.GREEN)
+	MHCT.HEALTH_GRADIENT_STOPS = {
+		LOW  = { lr, lg, lb },
+		MID  = { mr, mg, mb },
+		HIGH = { hr, hg, hb },
+	}
+end
 
 -- Local aliases for use within core.lua
 local STATUS_COLOR = MHCT.COLORS.STATUS
@@ -369,6 +399,32 @@ MHCT.getAbsorbText = function(unit, withTrailingSpace)
 
 	local text = "(" .. result .. ")"
 	return withTrailingSpace and (text .. " ") or text
+end
+
+-- Build a ColorCurveObject from HEALTH_GRADIENT_STOPS (0%, 50%, 100%).
+-- Midnight secret values block numeric percent + table lookup for text coloring, but
+-- UnitHealthPercent(unit, false, colorCurve) evaluates the gradient on the C side and
+-- returns a ColorMixin safe for GenerateHexColor(). See ColorCurveObject on warcraft.wiki.
+local HEALTH_COLOR_CURVE
+if CreateColorCurve and CreateColor and LuaCurveTypeLinear then
+	HEALTH_COLOR_CURVE = CreateColorCurve()
+	HEALTH_COLOR_CURVE:SetType(LuaCurveTypeLinear)
+	local lr, lg, lb = unpack(MHCT.HEALTH_GRADIENT_STOPS.LOW)
+	local mr, mg, mb = unpack(MHCT.HEALTH_GRADIENT_STOPS.MID)
+	local hr, hg, hb = unpack(MHCT.HEALTH_GRADIENT_STOPS.HIGH)
+	HEALTH_COLOR_CURVE:AddPoint(0.0, CreateColor(lr, lg, lb))
+	HEALTH_COLOR_CURVE:AddPoint(0.5, CreateColor(mr, mg, mb))
+	HEALTH_COLOR_CURVE:AddPoint(1.0, CreateColor(hr, hg, hb))
+end
+MHCT.HEALTH_COLOR_CURVE = HEALTH_COLOR_CURVE
+
+-- Returns opening color escape "|cffRRGGBB" for the unit's current health gradient color.
+-- nil when the curve is unavailable or evaluation fails (caller should use fallback).
+MHCT.getHealthGradientColorPrefix = function(unit)
+	if not unit or not HEALTH_COLOR_CURVE then return nil end
+	local ok, color = pcall(UnitHealthPercent, unit, false, HEALTH_COLOR_CURVE)
+	if not ok or not color then return nil end
+	return "|c" .. color:GenerateHexColor()
 end
 
 -------------------------------------

--- a/core.lua
+++ b/core.lua
@@ -64,7 +64,7 @@ local LuaCurveTypeLinear = Enum.LuaCurveType and Enum.LuaCurveType.Linear
 -- AbbreviateNumbers is AllowedWhenTainted in 12.0+ and accepts secret values natively.
 -- Guaranteed to exist since TOC floor is 120007 (WoW 12.0.7).
 local AbbreviateNumbers = AbbreviateNumbers
--- TruncateWhenZero (12.0.5+): returns nil when a value is zero, even for secret zeros.
+-- TruncateWhenZero (12.0.5+): returns "" when a value is zero (including secret zeros).
 -- Used to suppress absorb display when absorb is 0 but its value is restricted.
 local TruncateWhenZero = C_StringUtil and C_StringUtil.TruncateWhenZero
 local issecretvalue = issecretvalue
@@ -377,10 +377,8 @@ end
 --
 -- Zero-detection strategy:
 --   Non-secret: direct comparison (absorbAmount <= 0)
---   Secret:     C_StringUtil.TruncateWhenZero (12.0.5+) returns nil for secret zeros,
---               allowing us to suppress "(0)" that previously leaked through.
---               Without TruncateWhenZero (shouldn't happen given TOC 120007), we fall
---               through and show the value — worst case is a visible "(0)".
+--   Secret:     C_StringUtil.TruncateWhenZero returns "" for zero (not nil — empty string
+--               is truthy in Lua, so we must check == "" explicitly).
 MHCT.getAbsorbText = function(unit, withTrailingSpace)
 	if not unit then return "" end
 
@@ -390,12 +388,16 @@ MHCT.getAbsorbText = function(unit, withTrailingSpace)
 		-- Non-secret: nil or zero/negative means no absorb to display
 		if absorbAmount == nil or absorbAmount <= 0 then return "" end
 	else
-		-- Secret value: can't compare directly, but TruncateWhenZero handles secret zeros
-		if TruncateWhenZero and not TruncateWhenZero(absorbAmount) then return "" end
+		-- Secret value: can't compare directly; TruncateWhenZero handles secret zeros
+		if TruncateWhenZero then
+			local truncated = TruncateWhenZero(absorbAmount)
+			if truncated == nil or truncated == "" then return "" end
+		end
 	end
 
 	local result = MHCT.FormatLargeNumber(absorbAmount)
-	if result == nil then return "" end
+	-- Belt-and-suspenders: AbbreviateNumbers may still emit "0" if zero slipped through
+	if result == nil or result == "" or result == "0" then return "" end
 
 	local text = "(" .. result .. ")"
 	return withTrailingSpace and (text .. " ") or text

--- a/core.lua
+++ b/core.lua
@@ -56,15 +56,20 @@ local GetRaidRosterInfo = GetRaidRosterInfo
 -------------------------------------
 local UnitHealthPercent = UnitHealthPercent
 local UnitPowerPercent = UnitPowerPercent
+local UnitGetTotalAbsorbs = UnitGetTotalAbsorbs
+-- AbbreviateNumbers is AllowedWhenTainted in 12.0+ and accepts secret values natively.
+-- Guaranteed to exist since TOC floor is 120005.
+local AbbreviateNumbers = AbbreviateNumbers
+-- TruncateWhenZero (12.0.5+): returns nil when a value is zero, even for secret zeros.
+-- Used to suppress absorb display when absorb is 0 but its value is restricted.
+local TruncateWhenZero = C_StringUtil and C_StringUtil.TruncateWhenZero
 local issecretvalue = issecretvalue
-
--- Export for tag files
-MHCT.issecretvalue = issecretvalue
 
 -- Cache max player level at load time (doesn't change during session)
 local MAX_PLAYER_LEVEL_VALUE = GetMaxPlayerLevel()
 
--- ElvUI references - unpack once and share references
+-- ElvUI references - unpack once. Only E is shared with tag files (via MHCT.E);
+-- L is kept local since it's only used here for status string keys.
 local E, L = unpack(ElvUI)
 
 -------------------------------------
@@ -130,9 +135,8 @@ end
 
 checkCompatibility()
 
--- Export ElvUI references for tag modules to avoid duplicate unpacking
+-- Export E for tag modules (avoids re-unpacking ElvUI in each file)
 MHCT.E = E
-MHCT.L = L
 
 -------------------------------------
 -- CONSTANTS
@@ -147,10 +151,19 @@ MHCT.DEFAULT_DECIMAL_PLACE = 0
 -- Displayed when health/power values are restricted by Blizzard's secret value system
 MHCT.SECRET_VALUE_FALLBACK_TEXT = "---"
 
--- Status color constants
-local STATUS_COLOR = "D6BFA6"
-local BOSS_COLOR = "fc495e" -- light red
-local RARE_COLOR = "fc49f3" -- light magenta
+-- Shared color constants exported so tag files don't redefine them independently.
+-- classification.lua, misc.lua, and core.lua all reference these.
+MHCT.COLORS = {
+	STATUS = "D6BFA6",
+	BOSS   = "fc495e", -- light red
+	RARE   = "fc49f3", -- light magenta
+	ELITE  = "ffcc00", -- gold
+}
+
+-- Local aliases for use within core.lua
+local STATUS_COLOR = MHCT.COLORS.STATUS
+local BOSS_COLOR   = MHCT.COLORS.BOSS
+local RARE_COLOR   = MHCT.COLORS.RARE
 
 -- Common symbols
 local ELITE_SYMBOL = "+"
@@ -223,140 +236,86 @@ MHCT.CACHED_ICONS = CACHED_ICONS
 local pcall = pcall
 
 -- Safe boolean API call for WoW 12.x secret booleans.
--- Returns: true, false, or "secret" (for secret/error/nil cases).
+-- Returns: true, false, or "secret" (for secret/nil cases).
+--
+-- In Midnight (12.0+), boolean unit APIs (UnitIsAFK, UnitIsDead, etc.) return secret
+-- values in restricted contexts rather than throwing. issecretvalue() is the correct
+-- detection path — pcall() is unnecessary overhead here.
 local function getSafeBooleanState(apiFunc, unit)
 	if not apiFunc or not unit then
 		return "secret"
 	end
 
-	local ok, value = pcall(apiFunc, unit)
-	if not ok then
+	local value = apiFunc(unit)
+	if value == nil or issecretvalue(value) then
 		return "secret"
 	end
 
-	if issecretvalue(value) then
-		return "secret"
-	end
-
-	if value == nil then
-		return "secret"
-	end
-
-	if value == true then
-		return true
-	end
-
-	return false
+	return value == true
 end
 
--- Check if CurveConstants.ScaleTo100 is available (converts 0-1 to 0-100 range)
+-- CurveConstants.ScaleTo100 (Midnight) returns percent values in 0-100 directly,
+-- bypassing the legacy 0-1 multiplication. Resolved once at load (see GetHealthPercent).
 local CURVE_SCALE_TO_100 = CurveConstants and CurveConstants.ScaleTo100 or nil
-MHCT.CURVE_SCALE_TO_100 = CURVE_SCALE_TO_100
 
--- Get health percent in 0-100 range, secret-safe
+-- Get health percent in 0-100 range, secret-safe.
 -- Returns: percent (0-100), isSecret (boolean)
--- Uses CurveConstants.ScaleTo100 when available for direct 0-100 output
-MHCT.GetHealthPercent = function(unit)
-	if not unit then
-		return nil, false
-	end
-
-	local percent = nil
-	local isSecret = false
-	local hasPercent = false
-
-	-- Try CurveConstants.ScaleTo100 first (returns 0-100 directly)
-	if CURVE_SCALE_TO_100 then
+--
+-- CURVE_SCALE_TO_100 is checked once at load time so each call avoids a runtime branch.
+-- CurveConstants.ScaleTo100 gives 0-100 output directly; the legacy path scales *100.
+if CURVE_SCALE_TO_100 then
+	MHCT.GetHealthPercent = function(unit)
+		if not unit then return nil, false end
 		local ok, pct = pcall(UnitHealthPercent, unit, false, CURVE_SCALE_TO_100)
-		if ok and issecretvalue(pct) then
-			percent = pct
-			isSecret = true
-			hasPercent = true
-		elseif ok and pct ~= nil then
-			percent = pct
-			hasPercent = true
-		end
+		if not ok or pct == nil then return nil, false end
+		if issecretvalue(pct) then return pct, true end
+		return pct, false
 	end
-
-	-- Fallback: standard UnitHealthPercent (0-1 range), convert to 0-100
-	if not hasPercent then
+else
+	-- Legacy: UnitHealthPercent returns 0-1 range; scale to 0-100
+	MHCT.GetHealthPercent = function(unit)
+		if not unit then return nil, false end
 		local ok, pct = pcall(UnitHealthPercent, unit)
-		if ok and issecretvalue(pct) then
-			isSecret = true
-			percent = pct -- Will be 0-1, tag must handle this
-		elseif ok and pct ~= nil then
-			if not isSecret then
-				-- Can do arithmetic on non-secret values
-				percent = pct * 100
-			end
-		end
+		if not ok or pct == nil then return nil, false end
+		if issecretvalue(pct) then return pct, true end
+		return pct * 100, false
 	end
-
-	return percent, isSecret
 end
 
--- Get power percent in 0-100 range, secret-safe
+-- Get power percent in 0-100 range, secret-safe.
 -- Returns: percent (0-100), isSecret (boolean)
 -- powerType: optional, defaults to unit's primary power type
-MHCT.GetPowerPercent = function(unit, powerType)
-	if not unit then
-		return nil, false
-	end
-
-	-- Get power type if not specified
-	if not powerType then
-		powerType = UnitPowerType(unit)
-	end
-
-	local percent = nil
-	local isSecret = false
-	local hasPercent = false
-
-	-- Try CurveConstants.ScaleTo100 first (returns 0-100 directly)
-	if CURVE_SCALE_TO_100 then
+--
+-- Same load-time curve-path split as GetHealthPercent — removes per-call branching.
+if CURVE_SCALE_TO_100 then
+	MHCT.GetPowerPercent = function(unit, powerType)
+		if not unit then return nil, false end
+		if not powerType then powerType = UnitPowerType(unit) end
 		local ok, pct = pcall(UnitPowerPercent, unit, powerType, false, CURVE_SCALE_TO_100)
-		if ok and issecretvalue(pct) then
-			percent = pct
-			isSecret = true
-			hasPercent = true
-		elseif ok and pct ~= nil then
-			percent = pct
-			hasPercent = true
-		end
+		if not ok or pct == nil then return nil, false end
+		if issecretvalue(pct) then return pct, true end
+		return pct, false
 	end
-
-	-- Fallback: standard UnitPowerPercent (0-1 range), convert to 0-100
-	if not hasPercent then
+else
+	-- Legacy: UnitPowerPercent returns 0-1 range; scale to 0-100
+	MHCT.GetPowerPercent = function(unit, powerType)
+		if not unit then return nil, false end
+		if not powerType then powerType = UnitPowerType(unit) end
 		local ok, pct = pcall(UnitPowerPercent, unit, powerType)
-		if ok and issecretvalue(pct) then
-			isSecret = true
-			percent = pct -- Will be 0-1, tag must handle this
-		elseif ok and pct ~= nil then
-			if not isSecret then
-				percent = pct * 100
-			end
-		end
+		if not ok or pct == nil then return nil, false end
+		if issecretvalue(pct) then return pct, true end
+		return pct * 100, false
 	end
-
-	return percent, isSecret
 end
 
--- Format a number with K/M/B suffix, secret-safe
--- Uses AbbreviateNumbers (Midnight) or AbbreviateLargeNumbers (legacy)
+-- Format a number with K/M/B suffix, secret-safe.
+-- AbbreviateNumbers is AllowedWhenTainted in 12.0+ (warcraft.wiki.gg/wiki/API_AbbreviateNumbers)
+-- and accepts secret values natively — no pcall, no legacy fallback needed.
 MHCT.FormatLargeNumber = function(value)
 	if value == nil then
 		return MHCT.SECRET_VALUE_FALLBACK_TEXT
 	end
-	-- Prefer AbbreviateNumbers (Midnight API) over AbbreviateLargeNumbers (legacy)
-	local abbr = AbbreviateNumbers or AbbreviateLargeNumbers
-	if abbr then
-		local ok, result = pcall(abbr, value)
-		if ok and result then
-			return result
-		end
-	end
-	-- Final fallback: string.format (works with secrets)
-	return format("%d", value)
+	return AbbreviateNumbers(value)
 end
 
 -- Format percent value using cached patterns
@@ -383,6 +342,35 @@ MHCT.FormatPercent = function(percentValue, decimals, includeSign)
 	return result
 end
 
+-- Shared absorb text helper, used by health.lua and misc.lua.
+-- withTrailingSpace: true for inline use before a health value (e.g. "(25k) 100k").
+--
+-- Zero-detection strategy:
+--   Non-secret: direct comparison (absorbAmount <= 0)
+--   Secret:     C_StringUtil.TruncateWhenZero (12.0.5+) returns nil for secret zeros,
+--               allowing us to suppress "(0)" that previously leaked through.
+--               Without TruncateWhenZero (shouldn't happen given TOC 120005), we fall
+--               through and show the value — worst case is a visible "(0)".
+MHCT.getAbsorbText = function(unit, withTrailingSpace)
+	if not unit then return "" end
+
+	local absorbAmount = UnitGetTotalAbsorbs(unit)
+
+	if not issecretvalue(absorbAmount) then
+		-- Non-secret: nil or zero/negative means no absorb to display
+		if absorbAmount == nil or absorbAmount <= 0 then return "" end
+	else
+		-- Secret value: can't compare directly, but TruncateWhenZero handles secret zeros
+		if TruncateWhenZero and not TruncateWhenZero(absorbAmount) then return "" end
+	end
+
+	local result = MHCT.FormatLargeNumber(absorbAmount)
+	if result == nil then return "" end
+
+	local text = "(" .. result .. ")"
+	return withTrailingSpace and (text .. " ") or text
+end
+
 -------------------------------------
 -- HELPER FUNCTIONS
 -------------------------------------
@@ -406,9 +394,43 @@ MHCT.rgbToHex = function(r, g, b)
 	return format("%02X%02X%02X", r * 255, g * 255, b * 255)
 end
 
--- Removed - not used anywhere in the codebase
+-- Returns true when both player and unit are confirmed (non-secret, non-nil) max level.
+-- Centralizes the "hide at max level" comparison used by mh-smartlevel,
+-- mh-diff-level-hide, and mh-classification-name-level-smart.
+-- Returns false on any uncertainty (secret values, nil, mismatch) — the safe choice
+-- since a false negative just shows the level rather than hiding it.
+MHCT.isAtMaxLevelTogether = function(unit)
+	if not unit then return false end
+	local unitLevel = UnitEffectiveLevel(unit)
+	if unitLevel == nil or issecretvalue(unitLevel) then return false end
+	local playerLevel = UnitEffectiveLevel("player")
+	if playerLevel == nil or issecretvalue(playerLevel) then return false end
+	return playerLevel == MAX_PLAYER_LEVEL_VALUE and unitLevel == MAX_PLAYER_LEVEL_VALUE
+end
 
--- Optimized unit status check for ElvUI V15.0
+-- Returns (name, isSecret).
+-- Secret names can be passed to FontString for display but cannot be transformed
+-- (strupper, sub, #len check, etc. all break on secret strings in 12.0+).
+MHCT.getUnitNameSafe = function(unit)
+	if not unit then return nil, false end
+	local name = UnitName(unit)
+	if issecretvalue(name) then return name, true end
+	if name == nil or name == "" then return nil, false end
+	return name, false
+end
+
+-- Returns an UPPERCASE + length-capped name ready for display, or the raw secret name,
+-- or nil when the unit has no name. Centralizes the secret/nil guard that name.lua
+-- and combined.lua previously duplicated independently.
+MHCT.getFormattedUnitName = function(unit, length)
+	local name, isSecret = MHCT.getUnitNameSafe(unit)
+	if name == nil then return nil end
+	if isSecret then return name end
+	return E:ShortenString(strupper(name), length or MHCT.DEFAULT_TEXT_LENGTH)
+end
+
+-- Resolves the unit's display status (AFK, DND, Dead, Ghost, Offline) using
+-- secret-safe boolean reads. Returns the localized string or nil when none apply.
 MHCT.statusCheck = function(unit)
 	if not unit then
 		return nil
@@ -461,7 +483,10 @@ MHCT.getFormattedIcon = function(name, size, x, y)
 	return format(iconFormat, size or defaultSize, size or defaultSize, x or 0, y or 0)
 end
 
--- Optimized unit classification for ElvUI V14.0
+-- Returns the unit's classification key ("boss", "eliteplus", "elite", "rareelite",
+-- "rare", or the raw classification string) or nil for players / unresolvable units.
+-- All inputs are secret-checked since UnitClassification and UnitEffectiveLevel can
+-- both return secrets in restricted contexts.
 MHCT.classificationType = function(unit)
 	if not unit then
 		return nil

--- a/core.lua
+++ b/core.lua
@@ -11,7 +11,7 @@ local MHCT = ns.MHCT
 -------------------------------------
 -- ADDON VERSION INFO
 -------------------------------------
-MHCT.ADDON_VERSION = "10"
+MHCT.ADDON_VERSION = "11"
 MHCT.ADDON_NAME = "ElvUI_mhTags"
 
 -------------------------------------

--- a/core.lua
+++ b/core.lua
@@ -62,11 +62,13 @@ local CreateColor = CreateColor
 local CreateColorCurve = C_CurveUtil and C_CurveUtil.CreateColorCurve
 local LuaCurveTypeLinear = Enum.LuaCurveType and Enum.LuaCurveType.Linear
 -- AbbreviateNumbers is AllowedWhenTainted in 12.0+ and accepts secret values natively.
--- Guaranteed to exist since TOC floor is 120007 (WoW 12.0.7).
+-- Guaranteed to exist since TOC floor is 120005 (WoW 12.0.5).
 local AbbreviateNumbers = AbbreviateNumbers
--- TruncateWhenZero (12.0.5+): returns "" when a value is zero (including secret zeros).
--- Used to suppress absorb display when absorb is 0 but its value is restricted.
+-- TruncateWhenZero (12.0.5+): formats to integer string, or "" when zero (including secret zeros).
+-- WrapString (12.0+): joins prefix+infix+suffix only when infix is non-empty (C-side check; safe for secrets).
 local TruncateWhenZero = C_StringUtil and C_StringUtil.TruncateWhenZero
+local WrapString = C_StringUtil and C_StringUtil.WrapString
+local strconcat = string.concat
 local issecretvalue = issecretvalue
 
 -- Cache max player level at load time (doesn't change during session)
@@ -123,7 +125,7 @@ local function checkCompatibility()
 	if currentElvUIVersion > 0 and currentElvUIVersion < minElvUIVersion then
 		print(
 			format(
-				"|cffFF0000[ElvUI_mhTags Error]|r This addon requires ElvUI %.1f or higher for WoW 12.0.7 (Midnight). "
+				"|cffFF0000[ElvUI_mhTags Error]|r This addon requires ElvUI %.1f or higher for WoW 12.0.5 (Midnight). "
 					.. "Current version: %.2f. Please update ElvUI.",
 				minElvUIVersion,
 				currentElvUIVersion
@@ -376,31 +378,39 @@ end
 -- withTrailingSpace: true for inline use before a health value (e.g. "(25k) 100k").
 --
 -- Zero-detection strategy:
---   Non-secret: direct comparison (absorbAmount <= 0)
---   Secret:     C_StringUtil.TruncateWhenZero returns "" for zero (not nil — empty string
---               is truthy in Lua, so we must check == "" explicitly).
+--   Non-secret: direct comparison (absorbAmount <= 0), then AbbreviateNumbers
+--   Secret:     TruncateWhenZero + WrapString gate (C-side empty check); display via
+--               AbbreviateNumbers (secret-safe). Never compare TruncateWhenZero output to "" in Lua.
 MHCT.getAbsorbText = function(unit, withTrailingSpace)
 	if not unit then return "" end
 
 	local absorbAmount = UnitGetTotalAbsorbs(unit)
 
 	if not issecretvalue(absorbAmount) then
-		-- Non-secret: nil or zero/negative means no absorb to display
 		if absorbAmount == nil or absorbAmount <= 0 then return "" end
-	else
-		-- Secret value: can't compare directly; TruncateWhenZero handles secret zeros
-		if TruncateWhenZero then
-			local truncated = TruncateWhenZero(absorbAmount)
-			if truncated == nil or truncated == "" then return "" end
-		end
+		local result = AbbreviateNumbers(absorbAmount)
+		if result == nil or result == "" or result == "0" then return "" end
+		local text = strconcat("(", result, ")")
+		return withTrailingSpace and strconcat(text, " ") or text
 	end
 
-	local result = MHCT.FormatLargeNumber(absorbAmount)
-	-- Belt-and-suspenders: AbbreviateNumbers may still emit "0" if zero slipped through
-	if result == nil or result == "" or result == "0" then return "" end
+	-- Secret absorb: TruncateWhenZero only accepts numbers (not abbreviated strings).
+	if type(absorbAmount) ~= "number" or not TruncateWhenZero or not WrapString then
+		return ""
+	end
 
-	local text = "(" .. result .. ")"
-	return withTrailingSpace and (text .. " ") or text
+	local infix = TruncateWhenZero(absorbAmount)
+	if infix == nil then return "" end
+
+	-- WrapString returns normal "" when infix is empty (zero absorb); only compare when not secret.
+	local gate = WrapString(infix)
+	if not issecretvalue(gate) and gate == "" then return "" end
+
+	local result = AbbreviateNumbers(absorbAmount)
+	if not issecretvalue(result) and (result == nil or result == "" or result == "0") then return "" end
+
+	local text = strconcat("(", result, ")")
+	return withTrailingSpace and strconcat(text, " ") or text
 end
 
 -- Build a ColorCurveObject from HEALTH_GRADIENT_STOPS (0%, 50%, 100%).
@@ -768,7 +778,7 @@ SlashCmdList["MHTAGS"] = function(msg)
 		print("|cff0388fc[ElvUI_mhTags]|r Debug Information:")
 		print(format("  Addon Version: |cffffcc00%s|r", MHCT.ADDON_VERSION))
 		print(format("  ElvUI Version: |cffffcc00%.2f|r", info.elvuiVersion or 0))
-		print("  Target WoW Version: |cffffcc0012.0.7 (Midnight)|r")
+		print("  Target WoW Version: |cffffcc0012.0.5 (Midnight)|r")
 	elseif cmd == "help" then
 		print("|cff0388fc[ElvUI_mhTags]|r Commands:")
 		print("  |cffffcc00/mhtags|r - Show memory usage")

--- a/core.lua
+++ b/core.lua
@@ -62,7 +62,7 @@ local CreateColor = CreateColor
 local CreateColorCurve = C_CurveUtil and C_CurveUtil.CreateColorCurve
 local LuaCurveTypeLinear = Enum.LuaCurveType and Enum.LuaCurveType.Linear
 -- AbbreviateNumbers is AllowedWhenTainted in 12.0+ and accepts secret values natively.
--- Guaranteed to exist since TOC floor is 120005.
+-- Guaranteed to exist since TOC floor is 120007 (WoW 12.0.7).
 local AbbreviateNumbers = AbbreviateNumbers
 -- TruncateWhenZero (12.0.5+): returns nil when a value is zero, even for secret zeros.
 -- Used to suppress absorb display when absorb is 0 but its value is restricted.
@@ -123,7 +123,7 @@ local function checkCompatibility()
 	if currentElvUIVersion > 0 and currentElvUIVersion < minElvUIVersion then
 		print(
 			format(
-				"|cffFF0000[ElvUI_mhTags Error]|r This addon requires ElvUI %.1f or higher for WoW 12.0.5 (Midnight). "
+				"|cffFF0000[ElvUI_mhTags Error]|r This addon requires ElvUI %.1f or higher for WoW 12.0.7 (Midnight). "
 					.. "Current version: %.2f. Please update ElvUI.",
 				minElvUIVersion,
 				currentElvUIVersion
@@ -379,7 +379,7 @@ end
 --   Non-secret: direct comparison (absorbAmount <= 0)
 --   Secret:     C_StringUtil.TruncateWhenZero (12.0.5+) returns nil for secret zeros,
 --               allowing us to suppress "(0)" that previously leaked through.
---               Without TruncateWhenZero (shouldn't happen given TOC 120005), we fall
+--               Without TruncateWhenZero (shouldn't happen given TOC 120007), we fall
 --               through and show the value — worst case is a visible "(0)".
 MHCT.getAbsorbText = function(unit, withTrailingSpace)
 	if not unit then return "" end
@@ -766,7 +766,7 @@ SlashCmdList["MHTAGS"] = function(msg)
 		print("|cff0388fc[ElvUI_mhTags]|r Debug Information:")
 		print(format("  Addon Version: |cffffcc00%s|r", MHCT.ADDON_VERSION))
 		print(format("  ElvUI Version: |cffffcc00%.2f|r", info.elvuiVersion or 0))
-		print("  Target WoW Version: |cffffcc0012.0.5+ (Midnight)|r")
+		print("  Target WoW Version: |cffffcc0012.0.7 (Midnight)|r")
 	elseif cmd == "help" then
 		print("|cff0388fc[ElvUI_mhTags]|r Commands:")
 		print("  |cffffcc00/mhtags|r - Show memory usage")

--- a/tags/classification.lua
+++ b/tags/classification.lua
@@ -16,24 +16,25 @@ local format = string.format
 local CLASSIFICATION_SUBCATEGORY = "classification"
 local DEFAULT_ICON_SIZE = MHCT.DEFAULT_ICON_SIZE
 
--- Classification color constants
-local BOSS_COLOR = "fc495e" -- light red
-local ELITE_COLOR = "ffcc00" -- gold
-local RARE_COLOR = "fc49f3" -- light magenta
+-- Use centralized color constants from core.lua to avoid duplicate definitions.
+-- core.lua sets MHCT.COLORS before any tag file loads.
+local BOSS_COLOR  = MHCT.COLORS.BOSS
+local ELITE_COLOR = MHCT.COLORS.ELITE
+local RARE_COLOR  = MHCT.COLORS.RARE
 
 -- Pre-built classification text tables (avoid creating tables per call)
 local CLASSIFICATION_TEXT = {
-	boss = format("|cff%s[Boss]|r", BOSS_COLOR),
-	elite = format("|cff%s[Elite]|r", ELITE_COLOR),
-	rare = format("|cff%s[Rare]|r", RARE_COLOR),
+	boss     = format("|cff%s[Boss]|r",      BOSS_COLOR),
+	elite    = format("|cff%s[Elite]|r",     ELITE_COLOR),
+	rare     = format("|cff%s[Rare]|r",      RARE_COLOR),
 	rareelite = format("|cff%s[Rare Elite]|r", RARE_COLOR),
-	eliteplus = format("|cff%s[Elite+]|r", ELITE_COLOR),
+	eliteplus = format("|cff%s[Elite+]|r",   ELITE_COLOR),
 }
 
 local CLASSIFICATION_COMPACT = {
-	boss = format("|cff%sB|r", BOSS_COLOR),
-	elite = format("|cff%sE|r", ELITE_COLOR),
-	rare = format("|cff%sR|r", RARE_COLOR),
+	boss     = format("|cff%sB|r",  BOSS_COLOR),
+	elite    = format("|cff%sE|r",  ELITE_COLOR),
+	rare     = format("|cff%sR|r",  RARE_COLOR),
 	rareelite = format("|cff%sR+|r", RARE_COLOR),
 	eliteplus = format("|cff%sE+|r", ELITE_COLOR),
 }

--- a/tags/color.lua
+++ b/tags/color.lua
@@ -140,3 +140,22 @@ MHCT.registerTag(
 		return ""
 	end
 )
+
+-- ===================================================================================
+-- HEALTH GRADIENT COLOR
+-- Uses UnitHealthPercent + ColorCurveObject (Midnight secret-safe API).
+-- Numeric percent + precomputed table lookup cannot work when health is a secret value;
+-- the curve is evaluated on the C side and GenerateHexColor() produces the color code.
+-- Falls back to emerald-green when evaluation fails.
+-- ===================================================================================
+local SECRET_FALLBACK_COLOR = "|cff50C878" -- emerald-green; same hex as mh-color-emerald-green
+
+MHCT.registerTag(
+	"mh-color-health-gradient",
+	COLOR_SUBCATEGORY,
+	"Color prefix: 3-stop emerald gradient by health percent (emerald-red at low, emerald-yellow at mid, emerald-green at full). Composes with any health tag. Example: [mh-color-health-gradient][mh-health-current-percent]|r",
+	"UNIT_HEALTH UNIT_MAXHEALTH",
+	function(unit)
+		return MHCT.getHealthGradientColorPrefix(unit) or SECRET_FALLBACK_COLOR
+	end
+)

--- a/tags/color.lua
+++ b/tags/color.lua
@@ -116,8 +116,8 @@ local function validateHexColor(hex)
 	-- Remove # if present and convert to uppercase
 	hex = upper(hex:gsub("#", ""))
 
-	-- Validate: must be exactly 6 hex characters (0-9, A-F)
-	if match(hex, "^[0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F]$") then
+	-- Validate: exactly 6 hex characters; input is already uppercased so %x matches fine
+	if match(hex, "^%x%x%x%x%x%x$") then
 		return hex
 	end
 

--- a/tags/combined.lua
+++ b/tags/combined.lua
@@ -9,37 +9,15 @@
 local _, ns = ...
 local MHCT = ns.MHCT
 
-local E = MHCT.E
-local UnitName = UnitName
+-- UnitEffectiveLevel still used directly to fetch the unit's level for display.
+-- Level-comparison logic is delegated to MHCT.isAtMaxLevelTogether.
 local UnitEffectiveLevel = UnitEffectiveLevel
-local strupper = strupper
 local issecretvalue = issecretvalue
 
 local COMBINED_SUBCATEGORY = "combined"
 local DEFAULT_TEXT_LENGTH = MHCT.DEFAULT_TEXT_LENGTH
-local MAX_PLAYER_LEVEL = MHCT.MAX_PLAYER_LEVEL
 local EVENTS_COMBINED = "UNIT_CLASSIFICATION_CHANGED UNIT_NAME_UPDATE UNIT_LEVEL PLAYER_LEVEL_UP"
 local EVENTS_COMBINED_RAID = EVENTS_COMBINED .. " GROUP_ROSTER_UPDATE"
-
--- Helper: get unit name, handle secret values (same behavior as name.lua)
-local function getFormattedName(unit, length)
-	if not unit then
-		return nil
-	end
-	local name = UnitName(unit)
-	-- Check for secret value BEFORE doing any comparisons (WoW 12.0 group frames can return secrets)
-	if issecretvalue(name) then
-		return name
-	end
-	if name == nil then
-		return nil
-	end
-	-- Safe to compare now (not a secret)
-	if name == "" then
-		return nil
-	end
-	return E:ShortenString(strupper(name), length or DEFAULT_TEXT_LENGTH)
-end
 
 -- Helper: classification icon + name (optionally + difficulty level, optionally + raid group, optionally + smart level)
 -- Icon logic matches mh-classification-icon-fixed exactly (classificationType → ICON_MAP → getFormattedIcon).
@@ -55,8 +33,9 @@ local function getClassificationNameLevel(unit, includeLevel, nameLength, includ
 	local unitType = MHCT.classificationType(unit)
 	local iconStr = (unitType and MHCT.ICON_MAP[unitType]) and MHCT.getFormattedIcon(MHCT.ICON_MAP[unitType], MHCT.DEFAULT_ICON_SIZE) or ""
 
-	local nameStr = getFormattedName(unit, nameLength or DEFAULT_TEXT_LENGTH) or ""
-	-- Check for secret before comparing (PvP/targettarget can return secrets)
+	-- MHCT.getFormattedUnitName centralizes the secret/nil/empty guard and CAPS+shorten
+	local nameStr = MHCT.getFormattedUnitName(unit, nameLength or DEFAULT_TEXT_LENGTH) or ""
+	-- Secret names pass through as-is; skip raid group append since we can't compare them
 	local nameIsSecret = issecretvalue(nameStr)
 	if includeRaidGroup and not nameIsSecret and nameStr ~= "" then
 		nameStr = MHCT.appendRaidGroupToName(unit, nameStr)
@@ -66,24 +45,15 @@ local function getClassificationNameLevel(unit, includeLevel, nameLength, includ
 	local result = iconStr .. nameStr
 
 	if includeLevel then
-		local unitLevel = UnitEffectiveLevel(unit)
-		local shouldShowLevel = unitLevel ~= nil
-		-- Smart level: same logic as mh-smartlevel — hide when both player and unit are max level
-		-- Guard: only compare when both levels are comparable (WoW 12.0 can return secret values)
-		if useSmartLevel and unitLevel ~= nil and not issecretvalue(unitLevel) then
-			local playerLevel = UnitEffectiveLevel("player")
-			if playerLevel ~= nil
-				and not issecretvalue(playerLevel)
-				and playerLevel == MAX_PLAYER_LEVEL
-				and unitLevel == MAX_PLAYER_LEVEL
-			then
-				shouldShowLevel = false
-			end
-		end
-		if shouldShowLevel then
-			local levelStr = MHCT.difficultyLevelFormatter(unit, unitLevel)
-			if levelStr and levelStr ~= "" then
-				result = result .. " " .. levelStr
+		-- Smart level: hide entirely when player and unit are both confirmed max level.
+		-- Otherwise the difficulty formatter handles secret/nil internally.
+		if not (useSmartLevel and MHCT.isAtMaxLevelTogether(unit)) then
+			local unitLevel = UnitEffectiveLevel(unit)
+			if unitLevel ~= nil then
+				local levelStr = MHCT.difficultyLevelFormatter(unit, unitLevel)
+				if levelStr and levelStr ~= "" then
+					result = result .. " " .. levelStr
+				end
 			end
 		end
 	end

--- a/tags/health.lua
+++ b/tags/health.lua
@@ -13,17 +13,9 @@
 local _, ns = ...
 local MHCT = ns.MHCT
 
--- Get ElvUI references from core (shared to avoid duplicate unpacking)
-local E = MHCT.E
-
--- Localize Lua functions
-local format = string.format
-local pcall = pcall
-
 -- Localize WoW 12.0+ API functions (required - no fallbacks)
 local UnitHealth = UnitHealth
 local UnitHealthMissing = UnitHealthMissing
-local UnitGetTotalAbsorbs = UnitGetTotalAbsorbs
 local issecretvalue = issecretvalue
 
 -- ===================================================================================
@@ -34,10 +26,6 @@ local HEALTH_SUBCATEGORY = "health"
 
 -- Common display constants
 local VERTICAL_SEPARATOR = " | "
-
--- Pre-built common format strings to reduce concatenation
-local PERCENT_FORMAT = "%.1f%%"
-local DEFICIT_FORMAT = "-%s"
 
 -- Event constant groups for clarity and maintainability
 local EVENTS = {
@@ -54,61 +42,12 @@ local EVENTS = {
 
 -- Localize core utility functions for performance
 local FormatLargeNumber = MHCT.FormatLargeNumber
-local PERCENT_FORMATS = MHCT.PERCENT_FORMATS
-local GetHealthPercent = MHCT.GetHealthPercent
+local FormatPercent     = MHCT.FormatPercent
+local GetHealthPercent  = MHCT.GetHealthPercent
+local getAbsorbText     = MHCT.getAbsorbText
 
 -- Fallback text for secret values
 local SECRET_FALLBACK_TEXT = MHCT.SECRET_VALUE_FALLBACK_TEXT
-
--- Format absorb shield if present, secret-safe.
--- NOTE: Due to secret values, (0) may display when absorb is 0 and secret.
--- All comparison/detection methods are blocked: numeric comparison, string comparison, string length.
--- Returns plain text with parentheses; no color applied (user can use color tags if desired).
-local function getAbsorbText(unit)
-	if not unit then
-		return ""
-	end
-
-	local absorbAmount = UnitGetTotalAbsorbs(unit)
-	local absorbIsSecret = issecretvalue(absorbAmount)
-	if not absorbIsSecret and absorbAmount == nil then
-		return ""
-	end
-
-	-- Try to check if absorb is zero/negative (works for non-secret values only)
-	local ok, isZeroOrNegative = pcall(function() return absorbAmount <= 0 end)
-	
-	-- If comparison succeeded and absorb is zero/negative, hide it
-	if ok and isZeroOrNegative then
-		return ""
-	end
-	
-	-- If comparison failed (secret value), we cannot detect zero
-	-- Display the formatted value - may show (0) for secret zero values
-	local result = FormatLargeNumber(absorbAmount)
-	if result == nil then
-		return ""
-	end
-	
-	-- Return plain text with parentheses and trailing space (no color)
-	return "(" .. result .. ") "
-end
-
--- Local format helper using shared PERCENT_FORMATS from core.lua
-local function formatPercentValue(value, decimals)
-	if decimals < 0 then
-		decimals = 0
-	elseif decimals > 3 then
-		decimals = 3
-	end
-
-	local fmt = PERCENT_FORMATS[decimals]
-	if fmt then
-		return format(fmt, value)
-	end
-	-- Fallback for out-of-range decimals (shouldn't happen)
-	return format("%.0f", value)
-end
 
 -- ===================================================================================
 -- SECTION 1: BASIC HEALTH DISPLAY
@@ -148,11 +87,11 @@ MHCT.registerTag(
 		if not unit then
 			return ""
 		end
-		
-		local currentHp = UnitHealth(unit)
-		local absorbText = getAbsorbText(unit)
 
-		-- Use secret-safe formatting for current health
+		local currentHp = UnitHealth(unit)
+		-- withTrailingSpace=true so absorb and health are separated: "(25k) 100k"
+		local absorbText = getAbsorbText(unit, true)
+
 		local currentText = FormatLargeNumber(currentHp)
 		if currentText == nil then
 			return absorbText .. SECRET_FALLBACK_TEXT
@@ -189,10 +128,8 @@ MHCT.registerTag(
 			return SECRET_FALLBACK_TEXT
 		end
 
-		-- Format with requested decimals - string.format works on secret values
 		local decimals = MHCT.parseDecimalArg(args, 1)
-		local percentText = formatPercentValue(percent, decimals) .. "%"
-		return percentText
+		return FormatPercent(percent, decimals, true)
 	end
 )
 
@@ -212,16 +149,14 @@ MHCT.registerTag(
 			return statusFormatted
 		end
 
-		-- Get percent (0-100 range) - works even for secret values
 		local percent, percentIsSecret = GetHealthPercent(unit)
 		if not percentIsSecret and percent == nil then
 			return SECRET_FALLBACK_TEXT
 		end
 
-		-- Format with requested decimals - string.format works on secret values
 		local decimals = MHCT.parseDecimalArg(args, 1)
-		local percentText = formatPercentValue(percent, decimals)
-		return percentText
+		-- includeSign=false: returns raw number, no % appended
+		return FormatPercent(percent, decimals, false)
 	end
 )
 
@@ -253,9 +188,9 @@ MHCT.registerTag(
 			return SECRET_FALLBACK_TEXT
 		end
 
-		-- Use secret-safe formatting for both values
 		local currentText = FormatLargeNumber(currentHp)
-		local percentText = format(PERCENT_FORMAT, percent)
+		-- Fixed at 1 decimal to match original PERCENT_FORMAT ("%.1f%%")
+		local percentText = FormatPercent(percent, 1, true)
 		return currentText .. VERTICAL_SEPARATOR .. percentText
 	end
 )
@@ -283,9 +218,8 @@ MHCT.registerTag(
 			return SECRET_FALLBACK_TEXT
 		end
 
-		-- Use secret-safe formatting for both values
 		local currentText = FormatLargeNumber(currentHp)
-		local percentText = format(PERCENT_FORMAT, percent)
+		local percentText = FormatPercent(percent, 1, true)
 		return percentText .. VERTICAL_SEPARATOR .. currentText
 	end
 )
@@ -308,15 +242,15 @@ MHCT.registerTag(
 
 		local currentHp = UnitHealth(unit)
 		local percent, percentIsSecret = GetHealthPercent(unit)
-		local absorbText = getAbsorbText(unit)
+		-- withTrailingSpace=true so absorb prefixes inline: "(25k) 100k | 85%"
+		local absorbText = getAbsorbText(unit, true)
 
 		if not percentIsSecret and percent == nil then
 			return absorbText .. SECRET_FALLBACK_TEXT
 		end
 
-		-- Use secret-safe formatting for both values
 		local currentText = FormatLargeNumber(currentHp)
-		local percentText = format(PERCENT_FORMAT, percent)
+		local percentText = FormatPercent(percent, 1, true)
 		return absorbText .. currentText .. VERTICAL_SEPARATOR .. percentText
 	end
 )
@@ -350,8 +284,9 @@ MHCT.registerTag(
 			return ""
 		end
 
-		local deficitText = format(DEFICIT_FORMAT, E:ShortValue(missing))
-		return deficitText
+		-- FormatLargeNumber matches the abbreviation style of mh-health-current
+		-- (AbbreviateNumbers, e.g. "15k") so paired tags stay visually consistent
+		return "-" .. MHCT.FormatLargeNumber(missing)
 	end
 )
 
@@ -373,13 +308,14 @@ MHCT.registerTag(
 			return ""
 		end
 
-		local deficitText = format(DEFICIT_FORMAT, E:ShortValue(missing))
-		return deficitText
+		return "-" .. MHCT.FormatLargeNumber(missing)
 	end
 )
 
 -- Percentage deficit with status
--- Note: For secret values, we show the formatted percent as-is (can't calculate deficit)
+-- Note: Secret values (restricted PvP/encounters) cannot have arithmetic applied —
+-- 100 - secret would error. We already know isSecret from GetHealthPercent, so we
+-- branch directly instead of using a pcall closure.
 MHCT.registerTag(
 	"mh-health-deficit-percent",
 	HEALTH_SUBCATEGORY,
@@ -396,23 +332,18 @@ MHCT.registerTag(
 		end
 
 		local percent, percentIsSecret = GetHealthPercent(unit)
-		if not percentIsSecret and percent == nil then
+
+		-- Can't compute deficit on secret values; also nothing to show at full health
+		if percentIsSecret or percent == nil then
 			return ""
 		end
 
-		-- For secret values, we can format but not do arithmetic
-		-- Show as deficit format: display 100 - percent as "-X%"
-		-- Since we can't do 100 - secret, we format the raw percent
-		local decimals = MHCT.parseDecimalArg(args, 1)
-		
-		-- Use pcall to safely attempt arithmetic (will fail for secrets)
-		local ok, deficit = pcall(function() return 100 - percent end)
-		if ok and deficit > 0 then
-			local deficitText = "-" .. formatPercentValue(deficit, decimals) .. "%"
-			return deficitText
+		local deficit = 100 - percent
+		if deficit <= 0 then
+			return ""
 		end
-		
-		-- At full health or secret: no deficit to show
-		return ""
+
+		local decimals = MHCT.parseDecimalArg(args, 1)
+		return "-" .. FormatPercent(deficit, decimals, true)
 	end
 )

--- a/tags/misc.lua
+++ b/tags/misc.lua
@@ -1,36 +1,24 @@
 -- ===================================================================================
--- MISCELLANEOUS TAGS - Optimized for efficiency
+-- MISCELLANEOUS TAGS
 -- ===================================================================================
 --
 -- WoW 12.0+ Compatibility:
--- This file uses standard WoW APIs that are compatible with 12.0's secret value system.
--- Level and absorb APIs are not affected by the new restrictions.
+-- UnitEffectiveLevel and UnitGetTotalAbsorbs CAN return secret values in restricted
+-- contexts (rated PvP, encounters). Level comparisons are routed through
+-- MHCT.isAtMaxLevelTogether; absorb display is handled by MHCT.getAbsorbText.
 -- ===================================================================================
 local _, ns = ...
 local MHCT = ns.MHCT
 
 -- Localize Lua functions
 local format = string.format
-local pcall = pcall
 
 -- Localize WoW API functions
 local UnitEffectiveLevel = UnitEffectiveLevel
-local UnitGetTotalAbsorbs = UnitGetTotalAbsorbs
 local strupper = strupper
-local issecretvalue = issecretvalue
 
 -- Local constants
 local MISC_SUBCATEGORY = "misc"
-local MAX_PLAYER_LEVEL = MHCT.MAX_PLAYER_LEVEL
-
--- Check whether two level values can be safely compared.
--- Secret values cannot be compared in WoW 12.x.
-local function canCompareLevels(levelA, levelB)
-	if issecretvalue(levelA) or issecretvalue(levelB) then
-		return false
-	end
-	return levelA ~= nil and levelB ~= nil
-end
 
 -- ===================================================================================
 -- LEVEL TAGS
@@ -43,26 +31,12 @@ MHCT.registerTag(
 	"Simple tag to show all unit levels if player is not max level. If max level, will show level of all non max level units",
 	"UNIT_LEVEL PLAYER_LEVEL_UP",
 	function(unit)
-		if not unit then
-			return ""
-		end
-		local unitLevel = UnitEffectiveLevel(unit)
-		local playerLevel = UnitEffectiveLevel("player")
-
-		-- Optimize conditional logic - check if we need to show level at all
-		if canCompareLevels(playerLevel, unitLevel)
-			and playerLevel == MAX_PLAYER_LEVEL
-			and unitLevel == MAX_PLAYER_LEVEL
-		then
-			return ""
-		end
-
-		-- Otherwise just return the level
-		return unitLevel
+		if not unit then return "" end
+		-- Hide level entirely when both player and unit are confirmed max level
+		if MHCT.isAtMaxLevelTogether(unit) then return "" end
+		return UnitEffectiveLevel(unit)
 	end
 )
-
--- Removed - direct formatting is simpler
 
 MHCT.registerTag(
 	"mh-absorb",
@@ -70,34 +44,8 @@ MHCT.registerTag(
 	"Absorb shield amount in parentheses. No color applied; use with color tags if desired. Example: [mh-color-yellow][mh-absorb]|r",
 	"UNIT_ABSORB_AMOUNT_CHANGED",
 	function(unit)
-		if not unit then
-			return ""
-		end
-
-		local absorbAmount = UnitGetTotalAbsorbs(unit)
-		local absorbIsSecret = issecretvalue(absorbAmount)
-
-		-- Guard: only nil means unavailable (secret values are still displayable)
-		if not absorbIsSecret and absorbAmount == nil then
-			return ""
-		end
-
-		-- Try to check if absorb is zero/negative (works for non-secret values only)
-		local ok, isZeroOrNegative = pcall(function() return absorbAmount <= 0 end)
-		
-		-- If comparison succeeded and absorb is zero/negative, hide it
-		if ok and isZeroOrNegative then
-			return ""
-		end
-		
-		-- If comparison failed (secret value), we cannot detect zero
-		-- Display the formatted value - may show (0) for secret zero values
-		local result = MHCT.FormatLargeNumber(absorbAmount)
-		if result ~= nil then
-			return format("(%s)", result)
-		end
-
-		return ""
+		-- withTrailingSpace=false: standalone tag, no trailing space needed
+		return MHCT.getAbsorbText(unit, false)
 	end
 )
 
@@ -105,24 +53,12 @@ MHCT.registerTag(
 -- DIFFICULTY TAGS
 -- ===================================================================================
 
--- Helper function for difficulty level formatting
+-- Helper function for difficulty level formatting.
+-- hideAtMax: when true, returns "" if both player and unit are max level.
 local function formatDifficultyLevel(unit, hideAtMax)
-	if not unit then
-		return ""
-	end
-	local unitLevel = UnitEffectiveLevel(unit)
-	local playerLevel = UnitEffectiveLevel("player")
-
-	-- Check if we should hide the level
-	if hideAtMax
-		and canCompareLevels(playerLevel, unitLevel)
-		and playerLevel == unitLevel
-		and playerLevel == MAX_PLAYER_LEVEL
-	then
-		return ""
-	end
-
-	return MHCT.difficultyLevelFormatter(unit, unitLevel)
+	if not unit then return "" end
+	if hideAtMax and MHCT.isAtMaxLevelTogether(unit) then return "" end
+	return MHCT.difficultyLevelFormatter(unit, UnitEffectiveLevel(unit))
 end
 
 -- Then use this helper in both difficulty level tags
@@ -170,8 +106,6 @@ MHCT.registerTag(
 	end
 )
 
--- Removed - direct formatting is simpler
-
 MHCT.registerTag(
 	"mh-status-noicon",
 	MISC_SUBCATEGORY,
@@ -187,7 +121,8 @@ MHCT.registerTag(
 			return ""
 		end
 
-		return format("|cffD6BFA6%s|r", strupper(status))
+		-- Use MHCT.COLORS.STATUS to stay in sync with the status color defined in core.lua
+		return format("|cff%s%s|r", MHCT.COLORS.STATUS, strupper(status))
 	end
 )
 

--- a/tags/name.lua
+++ b/tags/name.lua
@@ -9,57 +9,17 @@
 local _, ns = ...
 local MHCT = ns.MHCT
 
--- Get ElvUI references from core (shared to avoid duplicate unpacking)
-local E = MHCT.E
-
--- Localize Lua functions
-local tonumber = tonumber
-
 -- Localize WoW API functions
-local UnitName = UnitName
+-- strupper is still needed directly in formatAbbreviatedName
 local strupper = strupper
-local issecretvalue = issecretvalue
 
 -- Local constants
 local NAME_SUBCATEGORY = "name"
 local DEFAULT_TEXT_LENGTH = MHCT.DEFAULT_TEXT_LENGTH
 
--- Helper: Get name safely, handling secret values
--- Returns: name, isSecret
--- For secret values, we return them as-is (can't transform but can display)
-local function getValidName(unit)
-	if not unit then
-		return nil, false
-	end
-	local name = UnitName(unit)
-	-- Secret values can still be displayed by FontString, but can't be transformed
-	if issecretvalue(name) then
-		return name, true
-	end
-	if name == nil then
-		return nil, false
-	end
-	-- Non-secret: check if empty
-	if name == "" then
-		return nil, false
-	end
-	return name, false
-end
-
--- Helper: Format name with uppercase and length limit (only works on non-secret)
-local function formatName(name, isSecret, length)
-	if isSecret then
-		-- Can't transform secret names, return as-is
-		return name
-	end
-	return E:ShortenString(strupper(name), length)
-end
-
 -- ===================================================================================
 -- NAME RELATED TAGS
 -- ===================================================================================
-
--- Removed - no need to cache empty string
 
 MHCT.registerTag(
 	"mh-name-caps",
@@ -67,13 +27,11 @@ MHCT.registerTag(
 	"Unit name in CAPS. Use {N} for max character length (default 28). Example: [mh-name-caps{20}]",
 	"UNIT_NAME_UPDATE",
 	function(unit, _, args)
-		local name, isSecret = getValidName(unit)
-		if name == nil then
-			return ""
-		end
-
 		local length = MHCT.parseDecimalArg(args, DEFAULT_TEXT_LENGTH)
-		return formatName(name, isSecret, length)
+		-- MHCT.getFormattedUnitName handles secret/nil/empty and CAPS+shorten in one call
+		local name = MHCT.getFormattedUnitName(unit, length)
+		if name == nil then return "" end
+		return name
 	end
 )
 
@@ -83,22 +41,15 @@ MHCT.registerTag(
 	"Shows status with icon when AFK, Dead, Offline, etc.; otherwise unit name in CAPS. Use {N} for max name length (default 28). Example: [mh-name-caps-or-status{20}]",
 	"UNIT_NAME_UPDATE UNIT_CONNECTION PLAYER_FLAGS_CHANGED UNIT_HEALTH INSTANCE_ENCOUNTER_ENGAGE_UNIT",
 	function(unit, _, args)
-		if not unit then
-			return ""
-		end
-		-- Check for status first (less common case)
+		if not unit then return "" end
+		-- Status check first; status wins over name display
 		local statusFormatted = MHCT.formatWithStatusCheck(unit)
-		if statusFormatted then
-			return statusFormatted
-		end
-
-		local name, isSecret = getValidName(unit)
-		if name == nil then
-			return ""
-		end
+		if statusFormatted then return statusFormatted end
 
 		local length = MHCT.parseDecimalArg(args, DEFAULT_TEXT_LENGTH)
-		return formatName(name, isSecret, length)
+		local name = MHCT.getFormattedUnitName(unit, length)
+		if name == nil then return "" end
+		return name
 	end
 )
 
@@ -108,39 +59,29 @@ MHCT.registerTag(
 	"Unit name in CAPS. In raid, appends raid group number (e.g. Name (3)). Use {N} for max name length (default 28). Example: [mh-name-caps-with-raid-group{20}]",
 	"UNIT_NAME_UPDATE GROUP_ROSTER_UPDATE",
 	function(unit, _, args)
-		local name, isSecret = getValidName(unit)
-		if name == nil then
-			return ""
-		end
-
 		local length = MHCT.parseDecimalArg(args, DEFAULT_TEXT_LENGTH)
-		local formatted = formatName(name, isSecret, length)
-		return MHCT.appendRaidGroupToName(unit, formatted)
+		local name = MHCT.getFormattedUnitName(unit, length)
+		if name == nil then return "" end
+		return MHCT.appendRaidGroupToName(unit, name)
 	end
 )
 
 -- ===================================================================================
--- Helper function for name abbreviation with configurable parameters
+-- Helper for abbreviation tags — uses MHCT.getUnitNameSafe so secret/nil handling
+-- is centralized in core.lua rather than repeated here.
 local function formatAbbreviatedName(unit, reverse, lengthThreshold)
-	local name, isSecret = getValidName(unit)
-	if name == nil then
-		return ""
-	end
+	local name, isSecret = MHCT.getUnitNameSafe(unit)
+	if name == nil then return "" end
+	-- Secret names can't be transformed (strupper/#len would error on them)
+	if isSecret then return name end
 
-	-- Secret names can't be transformed, return as-is
-	if isSecret then
-		return name
-	end
-
-	-- Convert to uppercase once
 	local uppercaseName = strupper(name)
 
-	-- If length threshold is provided, only abbreviate if name is longer
+	-- Only abbreviate when name exceeds the threshold (if one is given)
 	if lengthThreshold and #name <= lengthThreshold then
 		return uppercaseName
 	end
 
-	-- Use the abbreviate function with the uppercase name
 	return MHCT.abbreviate(uppercaseName, reverse, unit)
 end
 
@@ -171,7 +112,8 @@ MHCT.registerTag(
 	"Name in CAPS; abbreviates only if longer than {N} characters (default 25). Use {N} for length threshold. Example: [mh-name-abbrev-if-long{30}]",
 	"UNIT_NAME_UPDATE",
 	function(unit, _, nameLen)
-		return formatAbbreviatedName(unit, false, tonumber(nameLen) or 25)
+		-- Use parseDecimalArg for consistency with all other {N} tags
+		return formatAbbreviatedName(unit, false, MHCT.parseDecimalArg(nameLen, 25))
 	end
 )
 
@@ -181,6 +123,6 @@ MHCT.registerTag(
 	"Same as mh-name-abbrev-if-long but last word full. Use {N} for length threshold (default 25). Example: [mh-name-abbrev-if-long-reverse{30}]",
 	"UNIT_NAME_UPDATE",
 	function(unit, _, nameLen)
-		return formatAbbreviatedName(unit, true, tonumber(nameLen) or 25)
+		return formatAbbreviatedName(unit, true, MHCT.parseDecimalArg(nameLen, 25))
 	end
 )

--- a/tags/power.lua
+++ b/tags/power.lua
@@ -11,12 +11,9 @@
 local _, ns = ...
 local MHCT = ns.MHCT
 
--- Localize Lua functions
-local format = string.format
-
 -- Localize core utility functions
 local GetPowerPercent = MHCT.GetPowerPercent
-local PERCENT_FORMATS = MHCT.PERCENT_FORMATS
+local FormatPercent   = MHCT.FormatPercent
 
 -- Local constants
 local POWER_SUBCATEGORY = "power"
@@ -26,41 +23,20 @@ local DEFAULT_DECIMAL_PLACE = MHCT.DEFAULT_DECIMAL_PLACE
 -- HELPER FUNCTIONS
 -- ===================================================================================
 
--- Format power percent using secret-safe utility from core.lua
--- Returns formatted percent string or empty string for zero/unavailable
+-- Format power percent using secret-safe utilities from core.lua.
+-- Delegates clamping and formatting to MHCT.FormatPercent (no % sign for power).
+-- Secret values: CurveConstants.ScaleTo100 path in GetPowerPercent returns 0-100 even
+-- for secrets, so FormatPercent handles them correctly with no special-casing needed.
 local function formatPowerPercent(unit, decimalPlaces, powerType)
-	if not unit then
-		return ""
-	end
-	if decimalPlaces < 0 then
-		decimalPlaces = 0
-	elseif decimalPlaces > 3 then
-		decimalPlaces = 3
-	end
+	if not unit then return "" end
 
-	-- Get percent (0-100 range) using secret-safe utility
 	local percent, isSecret = GetPowerPercent(unit, powerType)
+	if percent == nil then return "" end
 
-	-- For secret values, we can still format using string.format
-	-- (CurveConstants.ScaleTo100 gives us 0-100 even for secrets)
-	if isSecret then
-		if percent == nil then
-			return ""
-		end
-		-- Basic format for secret values
-		return format("%.0f", percent)
-	end
-
-	if percent == nil then
-		return ""
-	end
-
-	-- Non-secret: use requested decimal places
-	local fmt = PERCENT_FORMATS[decimalPlaces]
-	if fmt then
-		return format(fmt, percent)
-	end
-	return format("%.0f", percent)
+	-- Power tags omit the % sign by convention (user can append it in ElvUI text format)
+	-- For secret values, fall back to 0 decimals since we can't know the precision
+	local decimals = isSecret and 0 or decimalPlaces
+	return FormatPercent(percent, decimals, false)
 end
 
 -- ===================================================================================


### PR DESCRIPTION
## Summary

- **`[mh-color-health-gradient]`** — new emerald health-percent gradient prefix tag using `UnitHealthPercent` + `ColorCurveObject` (secret-value safe; Lua table lookup is blocked in 12.0+)
- **Absorb `(0)` fix** — zero/secret-zero absorbs now suppressed via `TruncateWhenZero` + `WrapString`; non-secret absorbs still abbreviated (e.g. `(92.6K)`)
- **Interface `120005`** — corrects incorrect `120007` bump; targets WoW 12.0.5 (Midnight)
- **DRY refactor** — shared core helpers (`getAbsorbText`, `getFormattedUnitName`, `MHCT.COLORS`, etc.); tag files delegate instead of duplicating logic

## Test plan

- [ ] Addon loads without errors on WoW 12.0.5
- [ ] `[mh-color-health-gradient]` transitions emerald-red → emerald-yellow → emerald-green
- [ ] No `(0)` with no absorb shield
- [ ] Absorb shield shows value in parens; clears when shield drops
- [ ] Existing health, power, name, classification tags unchanged